### PR TITLE
Clean Dev DB on startup

### DIFF
--- a/src/main/java/org/justjava/gymcore/config/DevDatabaseInitializer.java
+++ b/src/main/java/org/justjava/gymcore/config/DevDatabaseInitializer.java
@@ -1,0 +1,25 @@
+package org.justjava.gymcore.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("dev")
+public class DevDatabaseInitializer implements CommandLineRunner {
+
+    private final Flyway flyway;
+
+    public DevDatabaseInitializer(Flyway flyway) {
+        this.flyway = flyway;
+    }
+
+    @Override
+    public void run(String... args) {
+        // Clean the database: drops all objects in the configured schema
+        flyway.clean();
+        // Re-run all migrations to set up a fresh database with test data
+        flyway.migrate();
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,3 +8,6 @@ spring.jpa.hibernate.ddl-auto=none
 # Load migrations from two locations: the main migrations and test data migrations
 spring.flyway.locations=classpath:db/migration,classpath:db/testdata
 spring.flyway.baseline-on-migrate=true
+
+# Allow cleaning the database in dev profile
+spring.flyway.clean-disabled=false


### PR DESCRIPTION
When running the application in dev profile, this will clean the DB of all data and load the test-data from the SQL file when the application is started. It does this via Flyway API.