### PR TITLE
GH-15 Add support for OpenApi docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ Specify 'dev' profile when running the application to trigger the dev profile. T
 
 If running via command line use `--spring.profiles.active=dev`
 If running via IDE, add `dev` to the active profiles in the run configuration.
+
+### Swagger UI
+To access the Swagger UI, navigate to `http://localhost:8080/api-docs` in your browser.
+From there you will also see a link to the OpenAPI specification in raw JSON format.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.flywaydb:flyway-core:11.3.1")
     implementation("org.flywaydb:flyway-database-postgresql:11.3.1")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0") // Version must be specified explicitly
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,3 +8,7 @@ spring.jpa.hibernate.ddl-auto=none
 # Load migrations from two locations: the main migrations and test data migrations
 spring.flyway.locations=classpath:db/migration,classpath:db/testdata
 spring.flyway.baseline-on-migrate=true
+
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.path=/api-docs
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
Swagger UI is now available at /api-docs
From there you can also click the link to generate the Open Api spec which can be imported directly into Postman for easy API testing