### PR TITLE
Add email sending functionality with Google SMTP

### DIFF
--- a/src/main/java/org/justjava/gymcore/config/smtp/AbstractSmtpConfig.java
+++ b/src/main/java/org/justjava/gymcore/config/smtp/AbstractSmtpConfig.java
@@ -1,0 +1,58 @@
+package org.justjava.gymcore.config.smtp;
+
+public abstract class AbstractSmtpConfig {
+    private String host;
+    private String port;
+    private String username; //use with encryption
+    private String password; //use with encryption
+    private String auth;
+    private String starttls;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getAuth() {
+        return auth;
+    }
+
+    public void setAuth(String auth) {
+        this.auth = auth;
+    }
+
+    public String getStarttls() {
+        return starttls;
+    }
+
+    public void setStarttls(String starttls) {
+        this.starttls = starttls;
+    }
+}

--- a/src/main/java/org/justjava/gymcore/config/smtp/GoogleSmtpConfig.java
+++ b/src/main/java/org/justjava/gymcore/config/smtp/GoogleSmtpConfig.java
@@ -1,0 +1,9 @@
+package org.justjava.gymcore.config.smtp;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "smtp.google")
+public class GoogleSmtpConfig extends AbstractSmtpConfig {
+}

--- a/src/main/java/org/justjava/gymcore/controller/MailController.java
+++ b/src/main/java/org/justjava/gymcore/controller/MailController.java
@@ -1,0 +1,22 @@
+package org.justjava.gymcore.controller;
+
+import org.justjava.gymcore.model.MailModel;
+import org.justjava.gymcore.service.MailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/mail")
+public class MailController {
+
+    @Autowired
+    private MailService mailService;
+
+    @PostMapping("/sendMail/{to}")
+    public ResponseEntity<HttpStatus> sendMail(@PathVariable("to") String to, @RequestBody MailModel mailModel) {
+        return mailService.sendMail(to, mailModel.subject(), mailModel.body());
+    }
+
+}

--- a/src/main/java/org/justjava/gymcore/controller/MailController.java
+++ b/src/main/java/org/justjava/gymcore/controller/MailController.java
@@ -11,8 +11,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping(value = "/mail")
 public class MailController {
 
-    @Autowired
-    private MailService mailService;
+    private final MailService mailService;
+
+    public MailController(MailService mailService) {
+        this.mailService = mailService;
+    }
 
     @PostMapping("/sendMail/{to}")
     public ResponseEntity<HttpStatus> sendMail(@PathVariable("to") String to, @RequestBody MailModel mailModel) {

--- a/src/main/java/org/justjava/gymcore/controller/MailController.java
+++ b/src/main/java/org/justjava/gymcore/controller/MailController.java
@@ -1,25 +1,35 @@
 package org.justjava.gymcore.controller;
 
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import lombok.RequiredArgsConstructor;
 import org.justjava.gymcore.model.MailModel;
 import org.justjava.gymcore.service.MailService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/mail")
+@RequiredArgsConstructor
 public class MailController {
 
     private final MailService mailService;
 
-    public MailController(MailService mailService) {
-        this.mailService = mailService;
-    }
-
     @PostMapping("/sendMail/{to}")
-    public ResponseEntity<HttpStatus> sendMail(@PathVariable("to") String to, @RequestBody MailModel mailModel) {
-        return mailService.sendMail(to, mailModel.subject(), mailModel.body());
+    public ResponseEntity<String> sendMail( @PathVariable("to")
+            @Email(message = "Invalid email address format")
+            String to,
+            @Valid @RequestBody MailModel mailModel) {
+        try {
+            mailService.sendMail(to, mailModel.subject(), mailModel.body());
+            return ResponseEntity.ok()
+                    .body("Email sent successfully to: " + to);
+        } catch (MessagingException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to send email: " + e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/org/justjava/gymcore/model/MailModel.java
+++ b/src/main/java/org/justjava/gymcore/model/MailModel.java
@@ -4,13 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record MailModel(
-    @NotBlank(message = "Email subject cannot be blank")
-    @Size(max = 998, message = "Email subject cannot exceed 998 characters")
-    String subject,
+        @NotBlank(message = "Email subject cannot be blank")
+        @Size(max = 998, message = "Email subject cannot exceed 998 characters")
+        String subject,
 
-    @NotBlank(message = "Email body cannot be blank")
-    @Size(max = 50000, message = "Email body cannot exceed 50KB")
-    String body
+        @NotBlank(message = "Email body cannot be blank")
+        @Size(max = 50000, message = "Email body cannot exceed 50KB")
+        String body
 ) {
-}
 }

--- a/src/main/java/org/justjava/gymcore/model/MailModel.java
+++ b/src/main/java/org/justjava/gymcore/model/MailModel.java
@@ -1,4 +1,16 @@
 package org.justjava.gymcore.model;
 
-public record MailModel(String subject, String body) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MailModel(
+    @NotBlank(message = "Email subject cannot be blank")
+    @Size(max = 998, message = "Email subject cannot exceed 998 characters")
+    String subject,
+
+    @NotBlank(message = "Email body cannot be blank")
+    @Size(max = 50000, message = "Email body cannot exceed 50KB")
+    String body
+) {
+}
 }

--- a/src/main/java/org/justjava/gymcore/model/MailModel.java
+++ b/src/main/java/org/justjava/gymcore/model/MailModel.java
@@ -1,0 +1,4 @@
+package org.justjava.gymcore.model;
+
+public record MailModel(String subject, String body) {
+}

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -6,24 +6,19 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.justjava.gymcore.config.smtp.GoogleSmtpConfig;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MailService {
-    @Autowired
+
     private GoogleSmtpConfig googleSmtpConfig;
 
     // Host, Host e-mail, password and port will be provided under yaml file. If you want to get configurations from yaml file use smtpConfigurationService.
-    public ResponseEntity<HttpStatus> sendMail(String to, String subject, String body) {
+    public void sendMail(String to, String subject, String body) throws MessagingException {
 
         Properties props = new Properties();
         props.put("mail.transport.protocol", "smtp");
@@ -40,8 +35,6 @@ public class MailService {
         };
 
         Session session = Session.getInstance(props, authenticator);
-
-        try {
             Message message = new MimeMessage(session);
             message.setFrom(new InternetAddress(googleSmtpConfig.getUsername()));
             message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to, false));
@@ -50,10 +43,5 @@ public class MailService {
 
             Transport.send(message);
             log.info("Email sent successfully to: {}", to);
-        } catch (MessagingException e) {
-            log.error("Failed to send email to {}: {}", to, e.getMessage(), e);;
-        }
-
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -23,7 +23,10 @@ public class MailService {
     private GoogleSmtpConfig googleSmtpConfig;
 
     // Host, Host e-mail, password and port will be provided under yaml file. If you want to get configurations from yaml file use smtpConfigurationService.
-    public ResponseEntity<HttpStatus> sendMail(String to, String subject, String body) {
+    public ResponseEntity<Void> sendMail(String to, String subject, String body) {
+        // existing mail‐sending logic
+        return ResponseEntity.ok().build();
+    }
         Logger logger = Logger.getLogger(MailService.class.getName());
 
 

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 @RequiredArgsConstructor
 public class MailService {
 
-    private GoogleSmtpConfig googleSmtpConfig;
+    private final GoogleSmtpConfig googleSmtpConfig;
 
     // Host, Host e-mail, password and port will be provided under yaml file. If you want to get configurations from yaml file use smtpConfigurationService.
     public void sendMail(String to, String subject, String body) throws MessagingException {

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -1,0 +1,60 @@
+package org.justjava.gymcore.service;
+
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.justjava.gymcore.config.smtp.GoogleSmtpConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    @Autowired
+    private GoogleSmtpConfig googleSmtpConfig;
+
+    // Host, Host e-mail, password and port will be provided under yaml file. If you want to get configurations from yaml file use smtpConfigurationService.
+    public ResponseEntity<HttpStatus> sendMail(String to, String subject, String body) {
+        Logger logger = Logger.getLogger(MailService.class.getName());
+
+
+        Properties props = new Properties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.host", googleSmtpConfig.getHost());
+        props.put("mail.smtp.auth", googleSmtpConfig.getAuth());
+        props.put("mail.smtp.port", googleSmtpConfig.getPort());
+        props.put("mail.smtp.starttls.enable", googleSmtpConfig.getStarttls());
+
+
+        Authenticator authenticator = new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(googleSmtpConfig.getUsername(), googleSmtpConfig.getPassword());
+            }
+        };
+
+        Session session = Session.getDefaultInstance(props, authenticator);
+
+        try {
+            Message message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(googleSmtpConfig.getUsername()));
+            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to, false));
+            message.setSubject(subject);
+            message.setText(body);
+
+            Transport.send(message);
+        } catch (MessagingException e) {
+            logger.log(Level.SEVERE, e.getMessage(), e);
+        }
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -41,7 +41,7 @@ public class MailService {
             }
         };
 
-        Session session = Session.getDefaultInstance(props, authenticator);
+        Session session = Session.getInstance(props, authenticator);
 
         try {
             Message message = new MimeMessage(session);

--- a/src/main/java/org/justjava/gymcore/service/MailService.java
+++ b/src/main/java/org/justjava/gymcore/service/MailService.java
@@ -23,12 +23,7 @@ public class MailService {
     private GoogleSmtpConfig googleSmtpConfig;
 
     // Host, Host e-mail, password and port will be provided under yaml file. If you want to get configurations from yaml file use smtpConfigurationService.
-    public ResponseEntity<Void> sendMail(String to, String subject, String body) {
-        // existing mail‐sending logic
-        return ResponseEntity.ok().build();
-    }
-        Logger logger = Logger.getLogger(MailService.class.getName());
-
+    public ResponseEntity<HttpStatus> sendMail(String to, String subject, String body) {
 
         Properties props = new Properties();
         props.put("mail.transport.protocol", "smtp");
@@ -54,8 +49,9 @@ public class MailService {
             message.setText(body);
 
             Transport.send(message);
+            log.info("Email sent successfully to: {}", to);
         } catch (MessagingException e) {
-            logger.log(Level.SEVERE, e.getMessage(), e);
+            log.error("Failed to send email to {}: {}", to, e.getMessage(), e);;
         }
 
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,12 @@ logging.level.org.justjava.gymcore=INFO
 #Google SMTP configurations
 smtp.google.host: smtp.gmail.com
 smtp.google.port: 587
-# smtp.google.username: your desired google mail address goes here
-# smtp.google.password: you generated google account application code goes here.
+# smtp.google.username: ${SMTP_USERNAME:your-email@gmail.com}
+# smtp.google.password: ${SMTP_PASSWORD:your-app-password}
 smtp.google.auth: true
 smtp.google.starttls: true
+
+# Security Note:
+# 1. Use environment variables for credentials in production
+# 2. For Gmail, use App Passwords instead of regular passwords
+# 3. Enable 2FA on your Google account before generating App Passwords

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,11 @@ logging.file.name=gymcore.log
 logging.appender.type=FILE
 logging.level.root=INFO
 logging.level.org.justjava.gymcore=INFO
+
+#Google SMTP configurations
+smtp.google.host: smtp.gmail.com
+smtp.google.port: 587
+# smtp.google.username: your desired google mail address goes here
+# smtp.google.password: you generated google account application code goes here.
+smtp.google.auth: true
+smtp.google.starttls: true


### PR DESCRIPTION
Introduces MailService, MailController, and MailModel to enable sending emails via Google SMTP. Adds configuration classes and properties for SMTP settings, allowing email dispatch through a REST endpoint.
![gymcorejpg](https://github.com/user-attachments/assets/b7506422-98ed-44ae-b75b-a62dbb46b6c1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to send emails via a new REST endpoint by specifying recipient, subject, and body.
  * Introduced support for Google SMTP configuration to enable email sending through Gmail.
  * Added configuration options for SMTP settings in the application properties.

* **Documentation**
  * Included guidance comments in the configuration file for setting up email credentials securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->