### PR TITLE
Add @JsonIgnore to prevent circular reference

### DIFF
--- a/src/main/java/org/justjava/gymcore/model/User.java
+++ b/src/main/java/org/justjava/gymcore/model/User.java
@@ -1,6 +1,8 @@
 package org.justjava.gymcore.model;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -43,6 +45,7 @@ public class User {
     private MembershipType membershipType;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @JsonIgnore
     private List<Booking> bookings = new ArrayList<>();
 
     public User(String name, String email, UserRole role, MembershipType membershipType) {


### PR DESCRIPTION
circular reference was present in calls including bookings/user objects. 

@JsonIgnore ignores the bookings field in User class.

Tests ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user profile API responses to exclude booking information from the serialized data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->